### PR TITLE
Build catkin ws during docker build, not at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ WORKDIR /root/catkin_ws/src/rcll_status_board
 RUN git checkout dockerized
 WORKDIR /root/catkin_ws/src
 
+RUN bash -c '\
+  source /opt/ros/melodic/setup.bash && \
+  cd /root/catkin_ws && \
+  catkin_make'
+
 # -----------#
 # Entrypoint #
 # -----------#

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 source /opt/ros/melodic/setup.bash
-cd /root/catkin_ws
-catkin_make
 source /root/catkin_ws/devel/setup.bash
 
 echo "==========================="


### PR DESCRIPTION
There is no need to re-build the catkin workspace every time we re-start
the container. Instead, do this while building the image.